### PR TITLE
iOS-1835 - UIKitCore crash

### DIFF
--- a/GMImagePicker/GMImagePickerController.m
+++ b/GMImagePicker/GMImagePickerController.m
@@ -130,28 +130,28 @@
 - (void)selectAsset:(PHAsset *)asset
 {
     if (asset) {
-    [self.selectedAssets insertObject:asset atIndex:self.selectedAssets.count];
-    [self updateDoneButton];
-    
-    if (!self.allowsMultipleSelection) {
-        if (self.confirmSingleSelection) {
-            NSString *message = self.confirmSingleSelectionPrompt ? self.confirmSingleSelectionPrompt : [NSString stringWithFormat:NSLocalizedStringFromTableInBundle(@"picker.confirm.message",  @"GMImagePicker", [NSBundle bundleForClass:GMImagePickerController.class],  @"Do you want to select the image you tapped on?")];
-            NSString *title = [NSString stringWithFormat:NSLocalizedStringFromTableInBundle(@"picker.confirm.title",  @"GMImagePicker", [NSBundle bundleForClass:GMImagePickerController.class],  @"Are You Sure?")];
-            UIAlertController *alertController = [UIAlertController alertControllerWithTitle:title message:message preferredStyle:UIAlertControllerStyleAlert];
-            NSString *yesTitle = [NSString stringWithFormat:NSLocalizedStringFromTableInBundle(@"picker.action.yes",  @"GMImagePicker", [NSBundle bundleForClass:GMImagePickerController.class],  @"Yes")];
-            [alertController addAction:[UIAlertAction actionWithTitle:yesTitle style:UIAlertActionStyleDefault handler:^(UIAlertAction *action) {
+        [self.selectedAssets insertObject:asset atIndex:self.selectedAssets.count];
+        [self updateDoneButton];
+        
+        if (!self.allowsMultipleSelection) {
+            if (self.confirmSingleSelection) {
+                NSString *message = self.confirmSingleSelectionPrompt ? self.confirmSingleSelectionPrompt : [NSString stringWithFormat:NSLocalizedStringFromTableInBundle(@"picker.confirm.message",  @"GMImagePicker", [NSBundle bundleForClass:GMImagePickerController.class],  @"Do you want to select the image you tapped on?")];
+                NSString *title = [NSString stringWithFormat:NSLocalizedStringFromTableInBundle(@"picker.confirm.title",  @"GMImagePicker", [NSBundle bundleForClass:GMImagePickerController.class],  @"Are You Sure?")];
+                UIAlertController *alertController = [UIAlertController alertControllerWithTitle:title message:message preferredStyle:UIAlertControllerStyleAlert];
+                NSString *yesTitle = [NSString stringWithFormat:NSLocalizedStringFromTableInBundle(@"picker.action.yes",  @"GMImagePicker", [NSBundle bundleForClass:GMImagePickerController.class],  @"Yes")];
+                [alertController addAction:[UIAlertAction actionWithTitle:yesTitle style:UIAlertActionStyleDefault handler:^(UIAlertAction *action) {
+                    [self finishPickingAssets:self];
+                }]];
+                NSString *noTitle = [NSString stringWithFormat:NSLocalizedStringFromTableInBundle(@"picker.action.no",  @"GMImagePicker", [NSBundle bundleForClass:GMImagePickerController.class],  @"No")];
+                [alertController addAction:[UIAlertAction actionWithTitle:noTitle style:UIAlertActionStyleCancel handler:nil]];
+                
+                [self presentViewController:alertController animated:YES completion:nil];
+            } else {
                 [self finishPickingAssets:self];
-            }]];
-            NSString *noTitle = [NSString stringWithFormat:NSLocalizedStringFromTableInBundle(@"picker.action.no",  @"GMImagePicker", [NSBundle bundleForClass:GMImagePickerController.class],  @"No")];
-            [alertController addAction:[UIAlertAction actionWithTitle:noTitle style:UIAlertActionStyleCancel handler:nil]];
-            
-            [self presentViewController:alertController animated:YES completion:nil];
-        } else {
-            [self finishPickingAssets:self];
+            }
+        } else if (self.displaySelectionInfoToolbar || self.showCameraButton) {
+            [self updateToolbar];
         }
-    } else if (self.displaySelectionInfoToolbar || self.showCameraButton) {
-        [self updateToolbar];
-    }
     }
 }
 

--- a/GMImagePicker/GMImagePickerController.m
+++ b/GMImagePicker/GMImagePickerController.m
@@ -129,6 +129,7 @@
 
 - (void)selectAsset:(PHAsset *)asset
 {
+    if (asset) {
     [self.selectedAssets insertObject:asset atIndex:self.selectedAssets.count];
     [self updateDoneButton];
     
@@ -150,6 +151,7 @@
         }
     } else if (self.displaySelectionInfoToolbar || self.showCameraButton) {
         [self updateToolbar];
+    }
     }
 }
 


### PR DESCRIPTION
https://console.firebase.google.com/u/0/project/later-ios/crashlytics/app/ios:it.latergram.latergram/issues/55a7125af494b164a54b299f0f8174d7?time=last-twenty-four-hours&sessionEventKey=bd3ba4b178534cc6b2d4d82150e8db5a_1475366907268565141

Fatal Exception: NSInvalidArgumentException
*** -[__NSArrayM insertObject:atIndex:]: object cannot be nil

Stack trace shows that there are 2 calls to GMImagePicker. The app seems to be crashing when a nil object is added to an array. My thought process is to make sure that `asset` is not nil before adding it to the `selectedAssets` array.